### PR TITLE
DMN fixes

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/contextmenu/ContextMenuView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/contextmenu/ContextMenuView.java
@@ -16,8 +16,9 @@
 
 package org.kie.workbench.common.dmn.client.editors.contextmenu;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
@@ -27,6 +28,8 @@ import elemental2.dom.DomGlobal;
 import elemental2.dom.Element;
 import elemental2.dom.Event;
 import elemental2.dom.EventListener;
+import jsinterop.base.Js;
+import jsinterop.base.JsArrayLike;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl;
@@ -81,13 +84,22 @@ public class ContextMenuView implements ContextMenu.View,
     }
 
     private final EventListener hideContextMenuHandler = event -> {
-        if (!Arrays.asList(getEventPath(event)).contains(getElement())) {
+        if (!getEventPath(event).contains(getElement())) {
             listSelector.hide();
         }
     };
 
-    Element[] getEventPath(Event event) {
-        return null;
+    List<Element> getEventPath(Event event) {
+        return Optional
+                .ofNullable(event.path)
+                .map(JsArrayLike::asList)
+                .orElseGet(() -> event.composedPath()
+                        .asList()
+                        .stream()
+                        .filter(e -> e instanceof Element)
+                        .map(obj -> (Element) Js.uncheckedCast(obj))
+                        .collect(Collectors.toList())
+                );
     }
 
     /**

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/contextmenu/ContextMenuViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/contextmenu/ContextMenuViewTest.java
@@ -16,15 +16,17 @@
 
 package org.kie.workbench.common.dmn.client.editors.contextmenu;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import elemental2.core.JsArray;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.Element;
 import elemental2.dom.Event;
+import elemental2.dom.EventTarget;
 import elemental2.dom.HTMLDocument;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl.ListSelectorItem;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl.ListSelectorTextItem;
@@ -36,11 +38,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@Ignore
 public class ContextMenuViewTest {
 
     private ContextMenuView contextMenuView;
@@ -106,48 +109,41 @@ public class ContextMenuViewTest {
     public void testWhenGettingEventPath() {
         final Event event = mock(Event.class);
         final Element element = mock(Element.class);
+        final List<EventTarget> pathArray = new ArrayList<>();
         final String value = "test-val";
-//        event.path = new Element[] {element};
+        event.path = spy(new JsArray<>());
+        pathArray.add(element);
 
+        doReturn(pathArray).when(event.path).asList();
         when(element.getAttribute(anyString())).thenReturn(value);
 
-        final Element[] eventPath = contextMenuView.getEventPath(event);
+        final List<Element> eventPath = contextMenuView.getEventPath(event);
 
         assertThat(eventPath).isNotNull();
         assertThat(eventPath).isNotEmpty();
-        assertThat(eventPath.length).isEqualTo(1);
-        assertThat(eventPath[0]).extracting(elem -> elem.getAttribute("test-attr")).isEqualTo(value);
+        assertThat(eventPath.size()).isEqualTo(1);
+        assertThat(eventPath.get(0)).extracting(elem -> elem.getAttribute("test-attr")).isEqualTo(value);
     }
 
     @Test
     public void testWhenGettingEventPathAndPathIsNull() {
         final Event event = mock(Event.class);
         final Element element = mock(Element.class);
+        final JsArray<EventTarget> composedPath = spy(new JsArray<>());
+        final List<EventTarget> composedPathAsList = new ArrayList<>();
         final String value = "test-val";
         event.path = null;
+        composedPathAsList.add(element);
 
-//        when(event.composedPath()).thenReturn(new Event.ComposedPathArrayUnionType[]{buildComposedPathArrayUnionType(element)});
+        doReturn(composedPathAsList).when(composedPath).asList();
+        when(event.composedPath()).thenReturn(composedPath);
         when(element.getAttribute(anyString())).thenReturn(value);
 
-        final Element[] eventPath = contextMenuView.getEventPath(event);
+        final List<Element> eventPath = contextMenuView.getEventPath(event);
 
         assertThat(eventPath).isNotNull();
         assertThat(eventPath).isNotEmpty();
-        assertThat(eventPath.length).isEqualTo(1);
-        assertThat(eventPath[0]).extracting(elem -> elem.getAttribute("test-attr")).isEqualTo(value);
+        assertThat(eventPath.size()).isEqualTo(1);
+        assertThat(eventPath.get(0)).extracting(elem -> elem.getAttribute("test-attr")).isEqualTo(value);
     }
-
-//    private Event.ComposedPathArrayUnionType buildComposedPathArrayUnionType(Element element) {
-//        return new Event.ComposedPathArrayUnionType() {
-//                @Override
-//                public boolean isElement() {
-//                    return true;
-//                }
-//
-//                @Override
-//                public Element asElement() {
-//                    return element;
-//                }
-//            };
-//    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/tour/providers/GraphElementsPositionProviderFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/tour/providers/GraphElementsPositionProviderFactory.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
-import elemental2.dom.ClientRect;
+import elemental2.dom.DOMRect;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLElement;
 import org.appformer.kogito.bridge.client.guided.tour.GuidedTourCustomSelectorPositionProvider.PositionProviderFunction;
@@ -67,7 +67,7 @@ public class GraphElementsPositionProviderFactory implements PositionProviderFac
     private Rect calculateNodeRelativePosition(final NodeImpl<View> node) {
 
         final Bounds bounds = node.getContent().getBounds();
-        final Optional<ClientRect> containerRect = getContainerRect();
+        final Optional<DOMRect> containerRect = getContainerRect();
         final double canvasLeft = containerRect.map(rect -> rect.left).orElse(0d);
         final double canvasTop = containerRect.map(rect -> rect.top).orElse(0d);
 
@@ -95,7 +95,7 @@ public class GraphElementsPositionProviderFactory implements PositionProviderFac
         return rect;
     }
 
-    private Optional<ClientRect> getContainerRect() {
+    private Optional<DOMRect> getContainerRect() {
         final Optional<HTMLElement> containerElement = getWiresCanvas().map(wiresCanvas -> elemental2DomUtil.asHTMLElement(wiresCanvas.getView().getElement()));
         return containerElement.map(Element::getBoundingClientRect);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/tour/providers/HTMLElementsPositionProviderFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/tour/providers/HTMLElementsPositionProviderFactory.java
@@ -18,7 +18,7 @@ package org.kie.workbench.common.dmn.webapp.kogito.common.client.tour.providers;
 
 import java.util.Optional;
 
-import elemental2.dom.ClientRect;
+import elemental2.dom.DOMRect;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLDocument;
@@ -36,7 +36,7 @@ public class HTMLElementsPositionProviderFactory implements PositionProviderFact
 
     private Rect makeRect(final Element element) {
 
-        final ClientRect clientRect = element.getBoundingClientRect();
+        final DOMRect clientRect = element.getBoundingClientRect();
 
         final int bottom = (int) clientRect.bottom;
         final int top = (int) clientRect.top;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/tour/providers/GraphElementsPositionProviderFactoryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/tour/providers/GraphElementsPositionProviderFactoryTest.java
@@ -26,7 +26,6 @@ import org.appformer.kogito.bridge.client.guided.tour.GuidedTourCustomSelectorPo
 import org.appformer.kogito.bridge.client.guided.tour.service.api.Rect;
 import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
@@ -65,7 +64,6 @@ public class GraphElementsPositionProviderFactoryTest {
     }
 
     @Test
-    @Ignore
     public void testGetPositionProviderFunction() {
         final PositionProviderFunction providerFunction = utils.createPositionProvider();
         final NodeImpl<View> decisionNode = makeNodeImpl("0000", 10, 10, 50, 100);
@@ -115,7 +113,7 @@ public class GraphElementsPositionProviderFactoryTest {
     }
 
     private DOMRect makeClientRect(final double top,
-                                      final double left) {
+                                   final double left) {
         final DOMRect clientRect = new DOMRect();
         clientRect.top = top;
         clientRect.left = left;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/tour/providers/HTMLElementsPositionProviderFactoryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/tour/providers/HTMLElementsPositionProviderFactoryTest.java
@@ -22,7 +22,6 @@ import elemental2.dom.Element;
 import elemental2.dom.HTMLDocument;
 import org.appformer.kogito.bridge.client.guided.tour.service.api.Rect;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -48,7 +47,6 @@ public class HTMLElementsPositionProviderFactoryTest {
     }
 
     @Test
-    @Ignore
     public void testGetPositionProviderFunction() {
 
         final String selector = ".my-button--inside-of-iframe";


### PR DESCRIPTION
@porcelli, this PR contains DMN specific fixes related to the changes applied by `gwt290`. Most of the editor seems stable, except the Literal Expression editor (which relies on Monaco for code-completion/code-highlighting).

Probably, we will need to take a deeper look on Monaco setup on `appformer/uberfire-workbench/uberfire-workbench-client-views-patternfly` to understand the error.