### PR TITLE
BPMN Editor - Fix wrong use of JS API in variables field editor

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
@@ -39,11 +39,10 @@ import elemental2.dom.CSSProperties;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLAnchorElement;
 import elemental2.dom.HTMLDivElement;
-import elemental2.dom.HTMLInputElement;
 import elemental2.dom.HTMLLabelElement;
+import elemental2.dom.MouseEvent;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsType;
-import jsinterop.base.Js;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.gwtbootstrap3.client.ui.ValueListBox;
@@ -492,7 +491,7 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
 
     @EventHandler("closeButton")
     public void handleCloseButton(final ClickEvent e) {
-        Js.<HTMLInputElement>uncheckedCast(variableTagsSettings).click();
+        variableTagsSettings.dispatchEvent(new MouseEvent("click"));
     }
 
     @EventHandler("acceptButton")

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImplTest.java
@@ -36,9 +36,8 @@ import elemental2.dom.DOMRect;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLAnchorElement;
 import elemental2.dom.HTMLDivElement;
-import elemental2.dom.HTMLInputElement;
 import elemental2.dom.HTMLLabelElement;
-import jsinterop.base.Js;
+import elemental2.dom.MouseEvent;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.gwtbootstrap3.client.ui.ValueListBox;
@@ -434,7 +433,7 @@ public class VariableListItemWidgetViewImplTest {
     @Test
     public void testHandleCloseButton() {
         view.handleCloseButton(null);
-        verify(Js.<HTMLInputElement>uncheckedCast(variableTagsSettings)).click();
+        verify(variableTagsSettings, times(1)).dispatchEvent(any(MouseEvent.class));
     }
 
     @Test


### PR DESCRIPTION
Hey @porcelli 

You was right, a test was still failing for the gwt 2.9.0 upgrade, sorry. On the other hand, as commented, I already tested the UI changes and tested again, after thsi fix, at now both runtime and tests are working. 

Please lemme know if you need something else! :+1: 

BTW Tried to refactor a bit this view implementation to provide some more polite, elegant code, but it's still mixing elemental and gwt/bootstrap stuff, so after a while I ended up on a few hours with no much success yet, so just let's go for a first update that works, and this fix does the job.

Thanks!